### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/block-production-demo-resources.yml
+++ b/block-production-demo-resources.yml
@@ -721,7 +721,7 @@ Resources:
      Ref: DemoResourcesS3BucketName
     S3Key:
      Ref: DemoResourcesS3ObjectKey
-   Runtime: "nodejs4.3"
+   Runtime: "nodejs10.x"
    Timeout: 25
 
  RegisterCanaryApprovalFunctionExecutionRole:
@@ -823,7 +823,7 @@ Resources:
      Code:
        S3Bucket: !Ref DemoResourcesS3BucketName
        S3Key: !Ref DemoResourcesS3ObjectKey
-     Runtime: "nodejs4.3"
+     Runtime: "nodejs10.x"
      Timeout: "25"
      Environment:
        Variables:
@@ -857,7 +857,7 @@ Resources:
      Code:
        S3Bucket: !Ref DemoResourcesS3BucketName
        S3Key: !Ref DemoResourcesS3ObjectKey
-     Runtime: "nodejs4.3"
+     Runtime: "nodejs10.x"
      Timeout: "25"
      Environment:
        Variables:


### PR DESCRIPTION
CloudFormation templates in aws-codepipeline-block-production have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.